### PR TITLE
Option for immediate function call back upon receiving new heart beat data

### DIFF
--- a/sample_app/source/TestAntConnectionApp.mc
+++ b/sample_app/source/TestAntConnectionApp.mc
@@ -10,13 +10,23 @@ class TestAntConnectionApp extends Application.AppBase
     var sensor;
     var startTime = 0;
 
+    var isAutomaticCallBackEnabled = false;
+
     //-------------------------------------------
     function initialize() 
     {
         AppBase.initialize();
-        timer.start( method(:onTimerTic),100,true);
+        if(isAutomaticCallBackEnabled == false){
+            timer.start( method(:onTimerTic),100,true);
+        }
         startTime = System.getTimer();
     }
+    
+    function callbackFunction(heartData as ANTPlusHeartRateSensor.HeartData) as Void{
+        // addMsg calls Ui.requestUpdate();
+        addMsg(debugString(heartData));
+    }
+    
 
     function debugString(heartData as ANTPlusHeartRateSensor.HeartData) as String{
         var referenceTimeDifference = ( (heartData.getRegisterTime()-startTime)/1000.0  ).format("%.2f");// in seconds
@@ -28,6 +38,7 @@ class TestAntConnectionApp extends Application.AppBase
     {
         if (sensor.searchingForSensor())
         {
+            // calls Ui.requestUpdate()
             addMsg("searching...");
         }
         else
@@ -37,13 +48,15 @@ class TestAntConnectionApp extends Application.AppBase
                 addMsg(debugString(latestHeartData));
             }
         }
-        Ui.requestUpdate();
     }
 
     //-------------------------------------------
     function onStart(state) 
     {
         sensor = new ANTPlusHeartRateSensor.HeartStrapSensor();
+        if(isAutomaticCallBackEnabled){
+            sensor.setCallback(method(:callbackFunction));
+        }
     }
 
     //-------------------------------------------


### PR DESCRIPTION
In previous pull request https://github.com/mannyray/ANTPlusHeartStrap/pull/1, it was noted at the end that:

> How quickly the watch can process the data on its end. According to https://developer.garmin.com/connect-iq/api-docs/Toybox/Timer/Timer.html a timer can be run as frequently once every 50 milliseconds. In our code, of this PR, we use this timer in timer.start( method(:onTimerTic),100,true); to popLatestHeartData so it is possible that there in our code there is a 100 millisecond delay between ant communication arrival and us processing it.

In this PR, we address this delay concern. We add additional option to our code to have the ability to immediately process fresh heart beat data by adding a callback method approach. This can reduce delay in processing fresh data as well as reduce frequency of calling methods by removing usage of `Timer`.

This addition is similar to what is found in another heart sensor library `GenericChannelHeartRateBarrel` ( see code [here](https://github.com/garmin/connectiq-apps/blob/eb0497a0377bbcb9495749c4071e872f67ba81e3/barrels/GenericChannelHeartRateBarrel/source/AntPlusHeartRateSensor.mc#L110-L118) as a starting digging point), but I found the implementation there a bit convoluted with the various delegates.

The README, in this PR provides additional information.